### PR TITLE
Setup ovn using systemd services

### DIFF
--- a/README-5VM.md
+++ b/README-5VM.md
@@ -1,4 +1,8 @@
 20171208
+original
+20180307
+update for systemd via ovn-kubernetes RPMs
+---------------
 
 Install 5VM cluster on 1 physical (beaker) host
 Host is a Dell R730 with 4 port NIC card, 256Gb disk.
@@ -16,7 +20,7 @@ THE PHYSICAL HOST:
 
 The physical host is from a pool of hosts on beaker:
 wsfd-netdev31.ntdv.lab.eng.bos.redhat.com
-fedora-rawhide Server will be installed and /root will be expanded to 
+fedora-rawhide Server will be installed and /root will be expanded to
 fill the 256Gb disk.
 5 VMs will be created on it and the cluster will have a node per VM.
 
@@ -42,7 +46,7 @@ select Distro Tree Fedora-rawhide-20180204.n.1 Server x86_64
 Click Provision
 
 When this is done the host will be running Fedora-rawhide
-Your default ssh key will be installed the host and the 
+Your default ssh key will be installed the host and the
 default root password will be installed.
 
 ===================================
@@ -62,7 +66,7 @@ Use ssh-copy-id to copy the key to each of the hosts. ssh login to
 each of the hosts to make sure it works without passwords or prompts.
 
 Fedora Server provisions a very small root (15Gb). The following expands it
-to 235 which is enough to support the VMs. When the host runs out of 
+to 235 which is enough to support the VMs. When the host runs out of
 disk space the VMs pause until more space is available.
 # lvextend --size +220G /dev/mapper/fedora-root ; xfs_growfs /
 
@@ -103,14 +107,16 @@ I have a fork of vmscale that I work with. So I use:
 ...
 
 
-Edit file user_data to add the generated public key (above) in two
+Edit file "user_data" to add the generated public key (above) in two
 places in the file.  Ansible, in  a later step will copy this to
 each VM so you will be able to ssh to each VM.
 
-Edit the desired qcow2 file name, e.g,
-https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/CloudImages/x86_64/images/Fedora-Cloud-Base-Rawhide-20180204.n.0.x86_64.qcow2
-into vwget section and in the "virsh vol-create-as" section in the vmcreate.sh file.
-rawhide is built every day so the version changes every day. 
+Edit the desired qcow2 file name into "vmcreate.sh" file, fedora rawhide is here:
+https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/CloudImages/x86_64/images/
+qcow2image=<name of qcow2 file>
+e.g., qcow2image=Fedora-Cloud-Base-Rawhide-20180204.n.0.x86_64.qcow2
+
+rawhide is built every day so the version changes every day.
 
 Also, change NUM_VMS_PER_MACHINE to the number of nodes/host
 e.g., NUM_VMS_PER_MACHINE=${NUM_VMS_PER_MACHINE:-5}
@@ -128,9 +134,23 @@ as part of Fedora-27 Server.
 
 
 ==================
+If replacing an existing implementation:
+
+Cleanup the existing setup by running vmclean.sh after setting the
+correct number of VMs.
+
+# cd ~/vmscale
+# ./vmclean.sh
+# systemctl restart libvirt
+
+Also, delete old lines for the VMs from /etc/hosts.
+Also edit /root/.ssh/known_hosts
+and delete lines for old IP, host and fqn of the VMs.
+
+==================
 Install the 5 VMs that will be the nodes:
 
-edit vmcreate.sh to reference correct Fedora image in the wget section 
+edit vmcreate.sh to reference correct Fedora image in the wget section
 and in the "virsh vol-create-as" section
 Run vmcreate.sh to create the 5 VMs
 
@@ -146,84 +166,62 @@ Run vmcreate.sh to create the 5 VMs
  9     wsfd-netdev31.ntdv.lab.eng.bos.redhat.com-4 running
  10    wsfd-netdev31.ntdv.lab.eng.bos.redhat.com-5 running
 
-Manually configure the network on each of the 5 VMs on the host
 
-Manual configuration:
-ssh to each host in turn.
-# ssh 192.168.122.137 hostname
-wsfd-netdev31.ntdv.lab.eng.bos.redhat.com-3.example.com
-
-Find the IP addresses:
-# virsh net-dhcp-leases default
- Expiry Time          MAC address        Protocol  IP address          Hostname  Client ID or DUID
--------------------------------------------------------------------------------------------------------
- 2018-02-05 15:58:26  52:54:00:11:ab:e0  ipv4      192.168.122.137/24  -         ff:00:11:ab:e0:00:04:8a:4d:ed:1e:08:ae:42:91:8c:99:19:78:c3:84:23:93
- 2018-02-05 15:58:19  52:54:00:20:25:55  ipv4      192.168.122.103/24  -         ff:00:20:25:55:00:04:c3:60:21:61:c6:42:47:42:89:80:aa:46:1a:52:1c:2a
- 2018-02-05 15:58:26  52:54:00:61:1f:59  ipv4      192.168.122.193/24  -         ff:00:61:1f:59:00:04:5b:38:ce:ff:38:02:48:e9:a2:0e:83:0a:c0:cc:b5:d3
- 2018-02-05 15:58:26  52:54:00:c5:7e:17  ipv4      192.168.122.135/24  -         ff:00:c5:7e:17:00:04:c5:b6:14:c3:c6:9a:4b:50:8d:30:a5:a3:95:c2:cc:99
- 2018-02-05 15:58:26  52:54:00:f1:93:40  ipv4      192.168.122.38/24   -         ff:00:f1:93:40:00:04:ff:c1:25:61:99:0f:46:a8:ba:0c:d8:ca:7e:f9:91:b8
-
-ssh to each address and note the VM name
-Add a line to /etc/hosts
-echo 192.168.122.137 netdev31-3 >> /etc/hosts
-This allows easy future access by name:
-# ssh netdev31-3
+Run
+./get-hosts.sh >> /etc/hosts
+to get the lines needed for the VMs
 
 # cat /etc/hosts
 127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4
 ::1         localhost localhost.localdomain localhost6 localhost6.localdomain6
 
-192.168.122.137 netdev31-3 wsfd-netdev31.ntdv.lab.eng.bos.redhat.com-3.example.com
-192.168.122.103 netdev31-1 wsfd-netdev31.ntdv.lab.eng.bos.redhat.com-1.example.com
-192.168.122.193 netdev31-2 wsfd-netdev31.ntdv.lab.eng.bos.redhat.com-2.example.com
-192.168.122.135 netdev31-5 wsfd-netdev31.ntdv.lab.eng.bos.redhat.com-5.example.com
-192.168.122.38  netdev31-4 wsfd-netdev31.ntdv.lab.eng.bos.redhat.com-4.example.com
+192.168.122.240 netdev31-2 wsfd-netdev31.ntdv.lab.eng.bos.redhat.com-2.example.com
+192.168.122.165 netdev31-3 wsfd-netdev31.ntdv.lab.eng.bos.redhat.com-3.example.com
+192.168.122.234 netdev31-1 wsfd-netdev31.ntdv.lab.eng.bos.redhat.com-1.example.com
+192.168.122.154 netdev31-5 wsfd-netdev31.ntdv.lab.eng.bos.redhat.com-5.example.com
+192.168.122.189 netdev31-4 wsfd-netdev31.ntdv.lab.eng.bos.redhat.com-4.example.com
 
 
-Verify that master can ssh to all of the VMs without password. E.g.,
-
-The cluster will be the 5 VMs that you just verified.
+Run this to verify that master can ssh to all of the VMs without password.
+./try-vms.sh
+to try to ssh to each host and fqn. Answer "yes" when asked.
 
 ============================
-On master:
-openvswitch-ovn-kubernetes is available in fedora rawhide
+Install python on each VM (this is needed by ansible)
+./install-python.sh
 
 ============================
 Provision each VM to be part of the cluster:
 
-The VMs are up and the master can reach each of them so at this
+The VMs are up and the host can reach each of them so at this
 point we can provision the VMs to be part of the future cluster.
 
-Install python on each vm. Ansible requires this to work, e.g.,
-# ssh netdev31-1 dnf install -y python
+hosts5run       - script to run ansible-playbook
+hosts5play.yml  - the install playbook
+hosts5post1.yml - the cleanup/post-processing playbook
+hosts5          - the set of hosts
 
-hosts5run      - script to run ansible-playbook
-hosts5play.yml - the playbook
-hosts5         - the set of hosts
-
-hosts5play.yml does the following on each VM:
+./hosts5run install
+does the following on each VM:
 - install ansible
 - install packages from the various repos (beaker-fedora and fedora)
 - add the 172.30.0.0/16 CIDR to the insecure registries token
-- add the brew-pulp-docker01.web.prod.ext.phx2.redhat.com:8888 
+- add the brew-pulp-docker01.web.prod.ext.phx2.redhat.com:8888
   and registry.ops.openshift.com registries as insecure.
 - restart docker
 - restart the ovn-controller
 - copy /etc/hosts to each VM - gives names and IP of all nodes
 - set permissions on the excutables/scripts
-- Add iptables firewall rules for ovn ports 6641 and 6642
-- Ensure GENEVE's UDP port, 6081, isn't firewalled
 
-At this point we are ready to install Openshift. It won't start
-properly until ovnkube is run configuring Openshift to ovn.
+After this, ose is installed...
 
 ===================================
-Install Openshift
+Install Openshift-Ansible
 
-The Openshift install is done using playbooks that are found in 
+The Openshift install is done using playbooks that are found in
 an Openshift development puddle.
 
-Get the repo:
+On the host, netdev31, get the repo:
 # cat > /etc/yum.repos.d/openshift_additional.repo < EOF
 [AtomicOpenShift-3.9-Puddle]
 name=AtomicOpenShift-3.9-Puddle
@@ -233,24 +231,96 @@ enabled=1
 
 EOF
 
+On the host, netdev31, install the following:
 # dnf install \
 openshift-ansible \
 openshift-ansible-docs \
 openshift-ansible-playbooks \
 openshift-ansible-roles
 
-The osehosts file:
+============================
+At this point we are ready to install Openshift.
+
+The ose5hosts file:
 This file directs the install. There are several items to consider.
 
+The file must contain:
+os_sdn_network_plugin_name='cni'
+
 At present we have tested with 1 master and 1 etcd
+The host names are the VM's `hostname`
+
+# ./ose5run 
+ose5run facts|cluster|master|node|certs|uninstall
 
 Install Openshift from the puddle using CNI (ovn)
 (The install required python3)
-./run5ose
+./run5ose cluster
 
+==================================
+After OSE is installed, run this to repair the HACK and restart the daemons
+
+# ./hosts5run post
+This does the following:
+- re apply the HACK
+- restart the daemons
+- Add iptables firewall rules for ovn ports 6641 and 6642
+- Ensure GENEVE's UDP port, 6081, isn't firewalled
+
+At this point "oc get nodes" should show all nodes in a NotReady state.
+
+After OVN is intalled in a later step, they will report Ready.
+
+
+============================
+ovn is installed using 
+# ./oseovn
+oseovn install|installdevel|config|uninstall
+
+install - installs the openvswitch-ovn-kubernetes RPMs 
+          from the rpms in OCP or Fedora
+installdevel - installs the openvswitch-ovn-kubernetes RPMs
+          from local copies in vmscale/
+          During development the rpms can be built from the
+          ovn-kubernetes github repo.
+config  - get the configuration needed to access the API server
+uninstall - remove ovn components and configuration.
+
+1) Install either rpms from OCP or Fedora or rpms locally
+built from a github ovn-kubernetes clone.
+
+2) Run config to create the /etc/openvswitch/ovn_k8s.conf file 
+and /etc/sysconfig/ovn-kubernetes files and copy them to all nodes.
+Openshift is configured to use ovn here as well.  This also restarts
+the daemons. At this point "oc get nodes" should show all nodes in
+the Ready state.
+ 
+============================
+Notes on ovn-kubernetes rpms:
+
+There are 3 rpms built for ovn-kubernetes
+
+openvswitch-ovn-kubernetes is installed on the master and 
+all nodes.
+
+This is installed on the master
+  openvswitch-ovn-kubernetes-master
+and this is installed on all all nodes.
+  openvswitch-ovn-kubernetes-node
+
+The master and node rpms contain systemd configuration files.
+ovn-controller is run on all nodes.
+ovn-northd is run on the master.
+
+The openvswitch-ovn-kubernetes RPMs are available in fedora rawhide
+and in the OCP puddle.
+
+You can clone ovn-kubernetes and build the rpms there for any commit.
+Copy them here (vmscale/) and use "./oseovn installdevel" to install them.
 
 ========================
-When master and etcd are up:
+Openshift is configured to use ovn with the following.
+This is done in "./oseovn config".
 
 See if api is running
 # ssh netdev31-1 oc get --raw /healthz/ready
@@ -262,15 +332,6 @@ ok
 # ssh netdev31-1 oc adm policy add-cluster-role-to-user cluster-admin -z ovn
 # ssh netdev31-1 oc adm policy add-scc-to-user anyuid -z ovn
 # ssh netdev31-1 oc sa get-token ovn  > /etc/origin/master/ovn.token
-
-Manually create the /etc/sysconfig/ovn-kubernetes file.
-Get the needed information from the openshift master.
-Copy the file to each node. Masters and nodes use the same file. 
-Restart the ovn-kubernetes-master.service on the ovn master and on each node
-restart the ovn-kubernetes-node.service 
-
-templates/ovn-kubernetes-master-setup.sh.j2 
-is script that can be run on master to fill in the data.
 
 
 ==================

--- a/README-5VM.md
+++ b/README-5VM.md
@@ -222,7 +222,7 @@ The Openshift install is done using playbooks that are found in
 an Openshift development puddle.
 
 On the host, netdev31, get the repo:
-# cat > /etc/yum.repos.d/openshift_additional.repo < EOF
+# cat > /etc/yum.repos.d/openshift_additional.repo <<'EOF'
 [AtomicOpenShift-3.9-Puddle]
 name=AtomicOpenShift-3.9-Puddle
 baseurl=http://download.lab.bos.redhat.com/rcm-guest/puddles/RHAOS/AtomicOpenShift/3.9/latest/$basearch/os
@@ -255,7 +255,12 @@ ose5run facts|cluster|master|node|certs|uninstall
 
 Install Openshift from the puddle using CNI (ovn)
 (The install required python3)
-./run5ose cluster
+# ./run5ose cluster
+
+The above fails in the console install. Work around this by
+# ./run5ose master
+# ./run5ose node
+
 
 ==================================
 After OSE is installed, run this to repair the HACK and restart the daemons

--- a/get-hosts.sh
+++ b/get-hosts.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Create /etc/hosts entries for the VMs
+# add the report from running this to /etc/hosts
+
+ips=$(virsh net-dhcp-leases default | gawk '/ipv4/{ print $5}' | sed 's;/24;;')
+
+for ip in $ips
+do
+  fqn=$(ssh ${ip} hostname)
+  host=$(echo ${fqn} | sed 's/wsfd-//
+s/.ntdv.lab.eng.bos.redhat.com//
+s/.example.com//')
+  echo ${ip}  ${host}  ${fqn}
+done
+

--- a/hosts5
+++ b/hosts5
@@ -4,11 +4,14 @@
 # /etc/hosts has the ip name and fqn
 
 [cluster:children]
-nodes
 masters
+nodes
 
 [masters:children]
-osehost31_1
+osehost31_1master
+
+[osehost31_1master]
+netdev31-1
 
 [nodes:children]
 osehost31_1

--- a/hosts5play.yml
+++ b/hosts5play.yml
@@ -18,7 +18,7 @@
     with_items:
       - yum
       - yum-utils
-      - python2-dbus
+#     - python2-dbus
       - python3-dbus
       - firewalld
       - NetworkManager

--- a/hosts5play.yml
+++ b/hosts5play.yml
@@ -17,6 +17,7 @@
       {{ ansible_pkg_mgr }} name={{ item }} state=present
     with_items:
       - yum
+      - yum-utils
       - python2-dbus
       - python3-dbus
       - firewalld
@@ -27,9 +28,10 @@
       - openvswitch-ovn-common
       - openvswitch-ovn-central
       - openvswitch-ovn-vtep
-      - openvswitch-ovn-docker
       - openvswitch-ovn-host
-      - openvswitch-ovn-kubernetes
+      - iptables-services
+#     - openvswitch-ovn-docker
+#     - openvswitch-ovn-kubernetes
 
 # This didn't work... (Just let docker create a file)
 # - name: set up docker storage
@@ -53,10 +55,17 @@
 
   - name: hack4
     shell: systemctl daemon-reload
+
+  - name: turn of selinux
+    shell: setenforce 0
 # HACK HACK - bz 1508495 workaround
 
-  - name: start ovs
-    service: name=ovsdb-server state=restarted
+# This shouldn't be needed
+# - name: start ovs
+#   service: name=ovsdb-server state=restarted
+
+  - name: start openvswitch
+    service: name=openvswitch state=restarted
 
   - name: restart docker
     service: name=docker state=restarted
@@ -64,49 +73,17 @@
   - name: restart NetworkManager
     service: name=NetworkManager state=restarted
 
+  - name: restart firewalld
+    service: name=firewalld state=restarted
+
   - name: copy hosts
     copy: src=/etc/hosts dest=/etc/hosts
 
-# - name: copy openshift_additional.repo
-#   copy: src=/etc/yum.repos.d/openshift_additional.repo dest=/etc/yum.repos.d/openshift_additional.repo
-
-  - name: iptables 6641
-#   shell: iptables -A INPUT -p tcp -m state --state NEW -m tcp --dport 6641 -j ACCEPT
-    shell: iptables -A OS_FIREWALL_ALLOW -p tcp -m state --state NEW -m tcp --dport 6641 -j ACCEPT
-
-  - name: iptables 6642
-#   shell: iptables -A INPUT -p tcp -m state --state NEW -m tcp --dport 6642 -j ACCEPT
-    shell: iptables -A OS_FIREWALL_ALLOW -p tcp -m state --state NEW -m tcp --dport 6642 -j ACCEPT
+  - name: copy openshift_additional.repo
+    copy: src=/etc/yum.repos.d/openshift_additional.repo dest=/etc/yum.repos.d/openshift_additional.repo
 
   - name: Ensure GENEVE's UDP port isn't firewalled
     shell: /usr/share/openvswitch/scripts/ovs-ctl --protocol=udp --dport=6081 enable-protocol
 
-  - name: copy a file
-    copy: src=/root/vmscale/templates/ovn_k8s.conf.j2 dest=/etc/openvswitch/ovn_k8s.conf
-
-  - name: restart ovn-controller
-    service: name=ovn-controller state=restarted
-
-# service setup and control
-# (temp until this is in the rpm)
-  - name: master service
-    template: src=ovn-kubernetes-master.service.j2  dest=/usr/lib/systemd/system/ovn-kubernetes-master.service
-  - name: master script
-    template: src=ovn-kubernetes-master.sh.j2  dest=/usr/bin/ovn-kubernetes-master.sh
-  - name: make excutable
-    file:
-      path: /usr/bin/ovn-kubernetes-master.sh
-      mode: 0755
-  - name: node service
-    template: src=ovn-kubernetes-node.service.j2  dest=/usr/lib/systemd/system/ovn-kubernetes-node.service
-  - name: node script
-    template: src=ovn-kubernetes-node.sh.j2  dest=/usr/bin/ovn-kubernetes-node.sh
-  - name: make excutable
-    file:
-      path: /usr/bin/ovn-kubernetes-node.sh
-      mode: 0755
-# - name: ovn-kubernetes sysconfig
-#   template: src=templates/ovn-kubernetes.sysconfig.j2  dest=/etc/sysconfig/ovn-kubernetes
-  - name: restart ovn
-    service: name=ovn-kubernetes-node state=restarted
+#   service: name=ovn-kubernetes-node state=restarted
 

--- a/hosts5post1.yml
+++ b/hosts5post1.yml
@@ -1,0 +1,85 @@
+---
+# This playbook sets up the 5 VMs to be part of a cluster.
+# it is run after the cluster install
+
+- name: Install tasks for 1 host, 5 node, cluster
+  hosts: cluster
+  user: root
+
+  # the ose install reinstalls openvswitch so the hack must be redone.
+  tasks:
+
+# HACK HACK - bz 1508495 work around
+  - name: hack1
+    template: src=/root/vmscale/templates/ovs-vswitchd.service.j2 dest=/usr/lib/systemd/system/ovs-vswitchd.service
+
+  - name: hack2
+    template: src=/root/vmscale/templates/ovsdb-server.service.j2  dest=/usr/lib/systemd/system/ovsdb-server.service
+
+  - name: hack3
+    template: src=/root/vmscale/templates/openvswitch.j2 dest=/etc/sysconfig/openvswitch
+
+  - name: hack4
+    shell: systemctl daemon-reload
+
+  - name: turn of selinux
+    shell: setenforce 0
+# HACK HACK - bz 1508495 workaround
+
+# This shouldn't be needed
+# make sure all needed services are restarted.
+  - name: start ovs
+    service: name=ovsdb-server state=restarted
+
+  - name: start openvswitch
+    service: name=openvswitch state=restarted
+
+  - name: restart docker
+    service: name=docker state=restarted
+
+  - name: restart NetworkManager
+    service: name=NetworkManager state=restarted
+
+  - name: restart firewalld
+    service: name=firewalld state=restarted
+
+  - name: copy hosts
+    copy: src=/etc/hosts dest=/etc/hosts
+
+  - name: copy openshift_additional.repo
+    copy: src=/etc/yum.repos.d/openshift_additional.repo dest=/etc/yum.repos.d/openshift_additional.repo
+
+# The rules must be applied to the desired chain.
+  - name: iptables 6641
+#   shell: iptables -A INPUT -p tcp -m state --state NEW -m tcp --dport 6641 -j ACCEPT
+#   shell: iptables -A OS_FIREWALL_ALLOW -p tcp -m state --state NEW -m tcp --dport 6641 -j ACCEPT
+    shell: iptables -A IN_public_allow -p tcp -m state --state NEW -m tcp --dport 6641 -j ACCEPT
+
+  - name: iptables 6642
+#   shell: iptables -A INPUT -p tcp -m state --state NEW -m tcp --dport 6642 -j ACCEPT
+#   shell: iptables -A OS_FIREWALL_ALLOW -p tcp -m state --state NEW -m tcp --dport 6642 -j ACCEPT
+    shell: iptables -A IN_public_allow -p tcp -m state --state NEW -m tcp --dport 6642 -j ACCEPT
+
+  - name: iptables 10250
+    shell: iptables -A IN_public_allow -p tcp -m state --state NEW -m tcp --dport 10250 -j ACCEPT
+
+  - name: iptables 80
+    shell: iptables -A IN_public_allow -p tcp -m state --state NEW -m tcp --dport 80 -j ACCEPT
+
+  - name: iptables 443
+    shell: iptables -A IN_public_allow -p tcp -m state --state NEW -m tcp --dport 443 -j ACCEPT
+
+  - name: iptables 8443
+    shell: iptables -A IN_public_allow -p tcp -m state --state NEW -m tcp --dport 8443 -j ACCEPT
+
+  - name: iptables 4789
+    shell: iptables -A IN_public_allow -p udp -m state --state NEW -m udp --dport 4789 -j ACCEPT
+
+  - name: Ensure GENEVE's UDP port isn't firewalled
+    shell: /usr/share/openvswitch/scripts/ovs-ctl --protocol=udp --dport=6081 enable-protocol
+
+# At this point "oc get nodes" should show all nodes as "NotReady"
+# since ovn is not set up yet.
+
+
+

--- a/hosts5run
+++ b/hosts5run
@@ -1,5 +1,26 @@
 #!/bin/bash
 
+action="XX"
+if [ X$1 != "X" ]
+then
+  action=$1
+fi
+
 # this playbook sets up the VMs to be part of a cluster.
-ansible-playbook -i hosts5 hosts5play.yml
+if [ ${action} == "install" ]
+then
+  ansible-playbook -i hosts5 hosts5play.yml
+  exit 0
+fi
+
+
+# repairs damage from install and restarts the daemons
+if [ ${action} == "post" ]
+then
+  ansible-playbook -i hosts5 hosts5post1.yml
+  exit 0
+fi
+
+echo "hosts5run install|post"
+exit 1
 

--- a/install-python.sh
+++ b/install-python.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# install python on each vm
+
+hosts=$(gawk '/192.168.122/{ print $2 }' /etc/hosts)
+
+for host in ${hosts}
+do
+  echo "  "
+  echo "   INSTALLING PYTHON ON --------  ${host} ----------"
+  ssh ${host} dnf install -y python
+done

--- a/ose5hosts
+++ b/ose5hosts
@@ -1,7 +1,6 @@
 # Create an OSEv3 group that contains the masters and nodes groups
 # This is for 1 host and 5 VMs (netdev31 with 5 VMs)
 # This is only verified to work with 1 master and 1 etcd 
-
 [OSEv3:children]
 masters
 nodes
@@ -28,7 +27,8 @@ openshift_docker_insecure_registries=brew-pulp-docker01.web.prod.ext.phx2.redhat
 
 # OCP/OSE puddle
 #Version 3.9
-openshift_additional_repos=[{'id': 'aos39-playbook-rpm', 'name': 'aos39-playbook-rpm', 'baseurl': 'http://download-node-02.eng.bos.redhat.com/rcm-guest/puddles/RHAOS/AtomicOpenShift/3.9/latest/x86_64/os/', 'enabled': 1, 'gpgcheck': 0}]
+#openshift_additional_repos=[{'id': 'aos39-playbook-rpm', 'name': 'aos39-playbook-rpm', 'baseurl': 'http://aconole.bytheb.org/files/ovs', 'enabled': 1, 'gpgcheck': 0}]
+openshift_additional_repos=[{'id': 'aos39-playbook-rpm', 'name': 'aos39-playbook-rpm', 'baseurl': 'http://download-node-02.eng.bos.redhat.com/rcm-guest/puddles/RHAOS/AtomicOpenShift/3.9/v3.9.8-1_2018-03-14.1/x86_64/os/', 'enabled': 1, 'gpgcheck': 0}]
 
 
 # Allow all auth
@@ -50,35 +50,22 @@ os_sdn_network_plugin_name='cni'
 # put IP name fqn into /etc/hosts
 # 
 
-[etcd]
-netdev31-1
-
 # host group for masters
 [masters]
-netdev31-1
-# openshift_hostname=netdev31-1 wsfd-netdev31.ntdv.lab.eng.bos.redhat.com-1.example.com openshift_ip=192.168.122.103
+wsfd-netdev31.ntdv.lab.eng.bos.redhat.com-1.example.com
+
+[etcd]
+wsfd-netdev31.ntdv.lab.eng.bos.redhat.com-1.example.com
 
 # host group for nodes, includes region info
 [nodes]
-netdev31-1 openshift_node_labels="{'region': 'infra', 'zone': 'default'}"
-#openshift_hostname=wsfd-netdev31.ntdv.lab.eng.bos.redhat.com-1.example.com openshift_ip=192.168.122.103 openshift_node_labels="{'region': 'infra', 'zone': 'default'}"
+wsfd-netdev31.ntdv.lab.eng.bos.redhat.com-1.example.com openshift_node_labels="{'region': 'infra', 'zone': 'default'}"
 
-netdev31-2 openshift_node_labels="{'region': 'infra', 'zone': 'east'}"
-#openshift_hostname=wsfd-netdev31.ntdv.lab.eng.bos.redhat.com-2.example.com openshift_ip=192.168.122.193 openshift_node_labels="{'region': 'infra', 'zone': 'east'}"
+wsfd-netdev31.ntdv.lab.eng.bos.redhat.com-2.example.com openshift_node_labels="{'region': 'infra', 'zone': 'east'}"
 
-netdev31-3 openshift_node_labels="{'region': 'infra', 'zone': 'west'}"
-#openshift_hostname=wsfd-netdev31.ntdv.lab.eng.bos.redhat.com-3.example.com openshift_ip=192.168.122.137 openshift_node_labels="{'region': 'infra', 'zone': 'west'}"
+wsfd-netdev31.ntdv.lab.eng.bos.redhat.com-3.example.com openshift_node_labels="{'region': 'infra', 'zone': 'west'}"
 
-netdev31-4 openshift_node_labels="{'region': 'infra', 'zone': 'north'}"
-#openshift_hostname=wsfd-netdev31.ntdv.lab.eng.bos.redhat.com-4.example.com openshift_ip=192.168.122.38 openshift_node_labels="{'region': 'infra', 'zone': 'north'}"
+wsfd-netdev31.ntdv.lab.eng.bos.redhat.com-4.example.com openshift_node_labels="{'region': 'infra', 'zone': 'north'}"
 
-netdev31-5 openshift_node_labels="{'region': 'infra', 'zone': 'south'}"
-#openshift_hostname=wsfd-netdev31.ntdv.lab.eng.bos.redhat.com-5.example.com openshift_ip=192.168.122.135 openshift_node_labels="{'region': 'infra', 'zone': 'south'}"
-
-#192.168.122.103 netdev31-1 wsfd-netdev31.ntdv.lab.eng.bos.redhat.com-1.example.com
-#192.168.122.193 netdev31-2 wsfd-netdev31.ntdv.lab.eng.bos.redhat.com-2.example.com
-#192.168.122.137 netdev31-3 wsfd-netdev31.ntdv.lab.eng.bos.redhat.com-3.example.com
-#192.168.122.38  netdev31-4 wsfd-netdev31.ntdv.lab.eng.bos.redhat.com-4.example.com
-#192.168.122.135 netdev31-5 wsfd-netdev31.ntdv.lab.eng.bos.redhat.com-5.example.com
-
+wsfd-netdev31.ntdv.lab.eng.bos.redhat.com-5.example.com openshift_node_labels="{'region': 'infra', 'zone': 'south'}"
 

--- a/ose5run
+++ b/ose5run
@@ -1,20 +1,63 @@
 #!/bin/bash
 
+action="XX"
+if [ X$1 != "X" ]
+then
+  action=$1
+fi
+
 # Do the OSE install from a puddle
 # This requires python3
 
 # This verifies that the VMs are properly provisioned to install the cluster
-#ansible-playbook -i ose5hosts /usr/share/ansible/openshift-ansible/playbooks/byo/openshift_facts.yml -e 'ansible_python_interpreter=/usr/bin/python3'
+if [ ${action} == "facts" ]
+then
+  ansible-playbook -i ose5hosts /usr/share/ansible/openshift-ansible/playbooks/byo/openshift_facts.yml -e 'ansible_python_interpreter=/usr/bin/python3'
+  exit 0
+fi
 
 # this should install the OSE cluster
-#ansible-playbook -i ose5hosts /usr/share/ansible/openshift-ansible/playbooks/deploy_cluster.yml -e 'ansible_python_interpreter=/usr/bin/python3'
+if [ ${action} == "cluster" ]
+then
+  ansible-playbook -i ose5hosts /usr/share/ansible/openshift-ansible/playbooks/deploy_cluster.yml -e 'ansible_python_interpreter=/usr/bin/python3'
+  exit 0
+fi
 
 # Install the master - if deploy_cluster.yml failed
-# ansible-playbook -i ose5hosts /usr/share/ansible/openshift-ansible/playbooks/openshift-master/config.yml -e 'ansible_python_interpreter=/usr/bin/python3'
+if [ ${action} == "master" ]
+then
+  ansible-playbook -i ose5hosts /usr/share/ansible/openshift-ansible/playbooks/openshift-master/config.yml -e 'ansible_python_interpreter=/usr/bin/python3'
+  exit 0
+fi
+
+# Install etcd - if deploy_cluster.yml failed
+if [ ${action} == "etcd" ]
+then
+  ansible-playbook -i ose5hosts /usr/share/ansible/openshift-ansible/playbooks/openshift-etcd/config.yml -e 'ansible_python_interpreter=/usr/bin/python3'
+  exit 0
+fi
 
 # Install the nodes - if deploy_cluster.yml failed
-ansible-playbook -i ose5hosts /usr/share/ansible/openshift-ansible/playbooks/openshift-node/config.yml -e 'ansible_python_interpreter=/usr/bin/python3'
+if [ ${action} == "node" ]
+then
+  ansible-playbook -i ose5hosts /usr/share/ansible/openshift-ansible/playbooks/openshift-node/config.yml -e 'ansible_python_interpreter=/usr/bin/python3'
+  exit 0
+fi
+
+# redeploy the certificates
+if [ ${action} == "certs" ]
+then
+/playbooks/redeploy-certificates.yml
+  ansible-playbook -i ose5hosts /usr/share/ansible/openshift-ansible/playbooks/redeploy-certificates.yml -e 'ansible_python_interpreter=/usr/bin/python3'
+  exit 0
+fi
 
 # Uninstall the cluster
-#ansible-playbook -i ose5hosts /usr/share/ansible/openshift-ansible/playbooks/adhoc/uninstall.yml -e 'ansible_python_interpreter=/usr/bin/python3'
+if [ ${action} == "uninstall" ]
+then
+  ansible-playbook -i ose5hosts /usr/share/ansible/openshift-ansible/playbooks/adhoc/uninstall.yml -e 'ansible_python_interpreter=/usr/bin/python3'
+  exit 0
+fi
 
+echo "ose5run facts|cluster|master|node|certs|uninstall"
+exit 1

--- a/oseovn
+++ b/oseovn
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+# Install, configure and uninstall ovn
+# This is done after the cluster install
+# It uses the same hosts file
+
+action="XX"
+if [ X$1 != "X" ]
+then
+  action=$1
+fi
+
+# Do the OSE install from a puddle
+# This requires python3
+
+# this should install the OVN rpms on the cluster
+if [ ${action} == "install" ]
+then
+  ansible-playbook -i ose5hosts ovn-install.yml -e 'ansible_python_interpreter=/usr/bin/python3'
+  exit 0
+fi
+
+# this should install the OVN rpms on the cluster
+# ovn-kubernetes from local rpm
+if [ ${action} == "installdevel" ]
+then
+  ansible-playbook -i ose5hosts ovn-devel-install.yml -e 'ansible_python_interpreter=/usr/bin/python3'
+  exit 0
+fi
+
+# Create the config file and distribute to all nodes
+if [ ${action} == "config" ]
+then
+  ansible-playbook -i ose5hosts ovn-config.yml -e 'ansible_python_interpreter=/usr/bin/python3'
+  exit 0
+fi
+
+# Uninstall ovn rpms and config
+if [ ${action} == "uninstall" ]
+then
+  ansible-playbook -i ose5hosts ovn-uninstall.yml -e 'ansible_python_interpreter=/usr/bin/python3'
+  exit 0
+fi
+
+echo "oseovn install|installdevel|config|uninstall"
+exit 1

--- a/ovn-config.yml
+++ b/ovn-config.yml
@@ -1,0 +1,68 @@
+---
+# This playbook creates the OVN configuration file and installs
+# it on all nodes in the cluster
+# this is run after the openshift master is up
+
+- name: Create OVN config files
+  hosts: masters
+
+  tasks:
+  # this collects the configuration and creates files
+  # that will be fetched and copied to the nodes
+  - name: Configure ovn-kubernetes
+    script: scripts/ovn-config.sh
+
+  - name: fetch the ovn-kubernetes file
+    fetch:
+      src: /tmp/ovn-kubernetes
+      dest: /tmp/ovn-kubernetes
+      flat: yes
+
+  - name: fetch the ovn_k8s.conf file
+    fetch:
+      src: /tmp/ovn_k8s.conf
+      dest: /tmp/ovn_k8s.conf
+      flat: yes
+
+  - name: Copy ovn-kubernetes file to master
+    copy:
+       src: /tmp/ovn-kubernetes
+       dest: /etc/sysconfig/ovn-kubernetes
+
+  - name: Copy ovn_k8s.conf file to master
+    copy:
+       src: /tmp/ovn_k8s.conf
+       dest: /etc/openvswitch/ovn_k8s.conf
+
+  - name: daemon-reload
+    shell: systemctl daemon-reload
+
+  - name: enable ovn-kubernetes-master
+    shell: systemctl enable ovn-kubernetes-master
+
+  - name: start ovn-kubernetes-master
+    service: name=ovn-kubernetes-master state=restarted
+
+
+- name: Configure ovn-kubernetes nodes
+  hosts: nodes
+  tasks:
+  - name: Copy ovn-kubernetes file to node
+    copy:
+       src: /tmp/ovn-kubernetes
+       dest: /etc/sysconfig/ovn-kubernetes
+
+  - name: Copy ovn_k8s.conf file to node
+    copy:
+       src: /tmp/ovn_k8s.conf
+       dest: /etc/openvswitch/ovn_k8s.conf
+
+  - name: daemon-reload
+    shell: systemctl daemon-reload
+
+  - name: enable ovn-kubernetes-node
+    shell: systemctl enable ovn-kubernetes-node
+
+  - name: start ovn-kubernetes-node
+    service: name=ovn-kubernetes-node state=restarted
+

--- a/ovn-devel-install.yml
+++ b/ovn-devel-install.yml
@@ -1,0 +1,58 @@
+---
+# development openvswitch-ovn-kubernetes install
+#
+# This playbook installs OVN rpms on the cluster
+# the ovn-kubernetes rpms are built elsewhere and copied to this 
+# directory. They are copied to each node and installed
+
+- name: Install OVN rpms
+  hosts: nodes
+
+  tasks:
+  - name: install packages
+    action: >
+      {{ ansible_pkg_mgr }} name={{ item }} state=present
+    with_items:
+      - openvswitch-ovn-common
+      - openvswitch-ovn-central
+      - openvswitch-ovn-vtep
+      - openvswitch-ovn-host
+
+  - name: Copy ovn rpm file to server
+    copy:
+       src: openvswitch-ovn-kubernetes.fc28.x86_64.rpm
+       dest: /tmp/openvswitch-ovn-kubernetes.fc28.x86_64.rpm
+
+  - name: Copy ovn-node rpm file to server
+    copy:
+       src: openvswitch-ovn-kubernetes-node.fc28.x86_64.rpm
+       dest: /tmp/openvswitch-ovn-kubernetes-node.fc28.x86_64.rpm
+
+  - name: Install package.
+    action: >
+      {{ ansible_pkg_mgr }} name={{ item }} state=present
+    with_items:
+      - /tmp/openvswitch-ovn-kubernetes.fc28.x86_64.rpm
+      - /tmp/openvswitch-ovn-kubernetes-node.fc28.x86_64.rpm
+
+  - name: start ovn-controller
+    service: name=ovn-controller state=restarted
+
+- name: Install OVN-master rpm
+  hosts: masters
+
+  tasks:
+  - name: Copy ovn-master rpm file to server
+    copy:
+       src: openvswitch-ovn-kubernetes-master.fc28.x86_64.rpm
+       dest: /tmp/openvswitch-ovn-kubernetes-master.fc28.x86_64.rpm
+
+  - name: install OVN-master
+    action: >
+      {{ ansible_pkg_mgr }} name={{ item }} state=present
+    with_items:
+      - /tmp/openvswitch-ovn-kubernetes-master.fc28.x86_64.rpm
+
+  - name: start ovn-northd
+    service: name=ovn-northd state=restarted
+

--- a/ovn-install.yml
+++ b/ovn-install.yml
@@ -1,0 +1,41 @@
+---
+# This playbook installs OVN rpms on the cluster
+
+- name: Install OVN rpms
+  hosts: nodes
+
+  tasks:
+  - name: install OVN-kubernetes on nodes
+    action: >
+      {{ ansible_pkg_mgr }} name={{ item }} state=present
+    with_items:
+      - openvswitch-ovn-common
+      - openvswitch-ovn-central
+      - openvswitch-ovn-vtep
+      - openvswitch-ovn-host
+      - openvswitch-ovn-kubernetes
+      - openvswitch-ovn-kubernetes-node
+
+  - name: enable ovn-controller
+    shell: systemctl enable ovn-controller
+
+  - name: start ovn-controller
+    service: name=ovn-controller state=restarted
+
+
+- name: Install OVN-master rpm
+  hosts: masters
+
+  tasks:
+  - name: install OVN-master
+    action: >
+      {{ ansible_pkg_mgr }} name={{ item }} state=present
+    with_items:
+      - openvswitch-ovn-kubernetes-master
+
+  - name: enable ovn-northd
+    shell: systemctl enable ovn-northd
+
+  - name: start ovn-northd
+    service: name=ovn-northd state=restarted
+

--- a/ovn-uninstall.yml
+++ b/ovn-uninstall.yml
@@ -1,0 +1,96 @@
+---
+# This playbook removes OVN rpms and config from cluster
+
+- name: Uninstall OVN
+  hosts: nodes
+
+  tasks:
+  - name: stop ovn-kubernetes-node
+    service: name=ovn-kubernetes-node state=stopped
+    ignore_errors: yes
+
+  - name: disable ovn-kubernetes-node
+    shell: systemctl disable ovn-kubernetes-node
+    ignore_errors: yes
+
+  - name: stop ovn-controller
+    service: name=ovn-controller state=stopped
+    ignore_errors: yes
+
+  - name: disable ovn-controller
+    shell: systemctl disable ovn-controller
+    ignore_errors: yes
+
+  - name: stop ovs-vswitchd
+    service: name=ovs-vswitchd state=stopped
+    ignore_errors: yes
+
+  - name: disable ovs-vswitchd
+    shell: systemctl disable ovs-vswitchd
+    ignore_errors: yes
+
+  - name: stop ovsdb-server
+    service: name=ovsdb-server state=stopped
+    ignore_errors: yes
+
+  - name: disable ovsdb-server
+    shell: systemctl disable ovsdb-server
+    ignore_errors: yes
+
+  - name: uninstall packages
+    action: >
+      {{ ansible_pkg_mgr }} name={{ item }} state=removed
+    with_items:
+      - openvswitch-ovn-common
+      - openvswitch-ovn-central
+      - openvswitch-ovn-vtep
+      - openvswitch-ovn-host
+      - openvswitch-ovn-kubernetes
+      - openvswitch-ovn-kubernetes-node
+    ignore_errors: yes
+
+  - name: delete /etc/cni/net.d/10-ovn-kubernetes.conf
+    file:
+      state: absent
+      path: /etc/cni/net.d/10-ovn-kubernetes.conf
+    ignore_errors: yes
+
+  - name: delete /etc/sysconfig/ovn-kubernetes.rpmsave
+    file:
+      state: absent
+      path: /etc/sysconfig/ovn-kubernetes.rpmsave
+    ignore_errors: yes
+
+  - name: delete /etc/openvswitch/ovn_k8s.conf.rpmsave
+    file:
+      state: absent
+      path: /etc/openvswitch/ovn_k8s.conf.rpmsave
+    ignore_errors: yes
+
+- name: Uninstall OVN-master
+  hosts: masters
+
+  tasks:
+  - name: stop ovn-kubernetes-master
+    service: name=ovn-kubernetes-master state=stopped
+    ignore_errors: yes
+
+  - name: disable ovn-kubernetes-master
+    shell: systemctl disable ovn-kubernetes-master
+    ignore_errors: yes
+
+  - name: stop ovn-northd
+    service: name=ovn-northd state=stopped
+    ignore_errors: yes
+
+  - name: disable ovn-northd
+    shell: systemctl disable ovn-northd
+    ignore_errors: yes
+
+  - name: uninstall ovn-master package
+    action: >
+      {{ ansible_pkg_mgr }} name={{ item }} state=removed
+    with_items:
+      - openvswitch-ovn-kubernetes-master
+    ignore_errors: yes
+

--- a/scripts/ovn-config.sh
+++ b/scripts/ovn-config.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# run on master to configure ovn-kubernetes
+# The /etc/openvswitch/ovn_k8s.conf and /etc/sysconfig/ovn-kubernetes
+# are used by ovnkube to direct processing.
+# This script creates files that can be copied to the nodes
+
+oc create serviceaccount ovn  2>/dev/null
+oc adm policy add-cluster-role-to-user cluster-admin -z ovn  2>/dev/null
+oc adm policy add-scc-to-user anyuid -z ovn  2>/dev/null
+
+token=$(oc sa get-token ovn)
+
+cidr=$(gawk '/clusterNetworkCIDR:/{ print $2 }' /etc/origin/master/master-config.yaml)
+
+apifqn=$(hostname)
+apiip=$(host ${apifqn} | gawk '{ print $4 }')
+
+# edit the /etc/sysconfig/ovn-kubernetes file
+sed '/cluster_cidr=/d' < /etc/sysconfig/ovn-kubernetes > /tmp/ovn-kubernetes
+echo "cluster_cidr=${cidr}" >> /tmp/ovn-kubernetes
+
+# edit /etc/openvswitch/ovn_k8s.conf 
+sed "s/ovn_master_fqn/${apifqn}/
+s/token=/token=${token}/
+s/ovn_master_ip/${apiip}/" /etc/openvswitch/ovn_k8s.conf > /tmp/ovn_k8s.conf
+
+exit 0
+

--- a/templates/ovnkube.ovn_k8s.conf.j2
+++ b/templates/ovnkube.ovn_k8s.conf.j2
@@ -1,0 +1,5 @@
+# configuration for ovnkube-node service
+token={{ TOKEN }}
+apiserver={{ APISERVER }}
+ovn_master_ip={{ MASTER_IP }}
+cluster_cidr={{ CLUSTER_CIDR }}

--- a/templates/ovnkube.sysconfig.j2
+++ b/templates/ovnkube.sysconfig.j2
@@ -1,0 +1,28 @@
+# ovn-kubernetes config - all nodes and masters
+
+# This file configures the ovn cni plugin. When completed or changed
+# the file must be copied to each ovn-master and each ovn-node. The
+# ovn-kubernetes-master and ovn-kubernetes-node daemons must be restarted.
+
+# This file and /etc/openvswitch/ovn_k8s.conf, in combination, provide
+# all of the configuration options. See man 5 ovn_k8s.conf
+
+# The token can be created from information on the Openshift master
+# after Openshift is installed and the master is running.
+# Login to the openshift master and do the following commands once
+# to set up openshift for ovn. The token can be set either here or in
+# ovn_k8s.conf
+
+# oc create serviceaccount ovn
+# oc adm policy add-cluster-role-to-user cluster-admin -z ovn
+# oc adm policy add-scc-to-user anyuid -z ovn
+# oc sa get-token ovn  > /etc/origin/master/ovn.token
+
+# cluster_cidr - this contains the clusterNetworkCIDR from
+# /etc/origin/master/master-config.yaml
+cluster_cidr={{ clustercidr }}
+
+# When changes are made copy the file to each ovn-node and ovn-master
+# and restart ovn-kubernetes-master.service and ovn-kubernetes-node.service
+
+# configuration for ovnkube-node service

--- a/templates/ovs-vswitchd.service.j2
+++ b/templates/ovs-vswitchd.service.j2
@@ -13,6 +13,8 @@ Restart=on-failure
 Environment=HOME=/var/run/openvswitch
 EnvironmentFile=/etc/openvswitch/default.conf
 EnvironmentFile=-/etc/sysconfig/openvswitch
+ExecStartPre=-/usr/bin/chown :hugetlbfs /dev/hugepages
+ExecStartPre=-/usr/bin/chmod 0775 /dev/hugepages
 ExecStart=/usr/share/openvswitch/scripts/ovs-ctl \
           --no-ovsdb-server --no-monitor --system-id=random \
           start $OPTIONS

--- a/templates/ovsdb-server.service.j2
+++ b/templates/ovsdb-server.service.j2
@@ -2,7 +2,7 @@
 Description=Open vSwitch Database Unit
 After=syslog.target network-pre.target
 Before=network.target network.service
-ReloadPropagatedFrom=openvswitch.service
+Wants=ovs-delete-transient-ports.service
 PartOf=openvswitch.service
 
 [Service]
@@ -10,7 +10,6 @@ Type=forking
 Restart=on-failure
 EnvironmentFile=/etc/openvswitch/default.conf
 EnvironmentFile=-/etc/sysconfig/openvswitch
-#ExecStartPre=/bin/sh -c '/usr/bin/chown ${OVS_USER_ID} /var/run/openvswitch'
 ExecStart=/usr/share/openvswitch/scripts/ovs-ctl \
           --no-ovs-vswitchd --no-monitor --system-id=random \
           start $OPTIONS

--- a/try-vms.sh
+++ b/try-vms.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Try to ssh to each host and fqn of the VMs from the /etc/hosts file
+
+hosts=$(gawk '/192.168.122/{ print $2 "  " $3 }' /etc/hosts)
+
+for host in ${hosts}
+do
+  echo trying $host
+  ssh $host exit
+done

--- a/vmcreate.sh
+++ b/vmcreate.sh
@@ -17,6 +17,12 @@
 
 NUM_VMS_PER_MACHINE=${NUM_VMS_PER_MACHINE:-5}
 
+# qcow2 image for the VMs from:
+# https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/CloudImages/x86_64/images/
+# https://dl.fedoraproject.org/pub/fedora/linux/releases/27/CloudImages/x86_64/images/
+qcow2root=https://dl.fedoraproject.org/pub/fedora/linux/releases/27/CloudImages/x86_64/images
+#qcow2image=Fedora-Cloud-Base-Rawhide-20180303.n.0.x86_64.qcow2
+qcow2image=Fedora-Cloud-Base-27-1.6.x86_64.qcow2
 
 ## 
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
@@ -39,17 +45,13 @@ export STORAGE_PATH=${QCOW_INSTALL_DIR}/${STORAGE_DIR}
 mkdir -p ${STORAGE_PATH}
 pushd ${STORAGE_PATH}
 
-#### Get the qcow2 file for the VM
-# This setup uses fedora rawhide
-#qcow2image=Fedora-Cloud-Base-Rawhide-20180303.n.0.x86_64.qcow2
-qcow2image=Fedora-Cloud-Base-27-1.6.x86_64.qcow2
 
 #if [ ! -f CentOS-7-x86_64-GenericCloud.qcow2 ]; then
   #wget http://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud.qcow2.xz
   #unxz CentOS-7-x86_64-GenericCloud.qcow2.xz
 #fi
 if [ ! -f ${qcow2image} ]; then
-  wget https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/CloudImages/x86_64/images/${qcow2image}
+  wget ${qcow2root}/${qcow2image}
 fi
 
 popd

--- a/vmcreate.sh
+++ b/vmcreate.sh
@@ -39,12 +39,17 @@ export STORAGE_PATH=${QCOW_INSTALL_DIR}/${STORAGE_DIR}
 mkdir -p ${STORAGE_PATH}
 pushd ${STORAGE_PATH}
 
+#### Get the qcow2 file for the VM
+# This setup uses fedora rawhide
+#qcow2image=Fedora-Cloud-Base-Rawhide-20180303.n.0.x86_64.qcow2
+qcow2image=Fedora-Cloud-Base-27-1.6.x86_64.qcow2
+
 #if [ ! -f CentOS-7-x86_64-GenericCloud.qcow2 ]; then
   #wget http://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud.qcow2.xz
   #unxz CentOS-7-x86_64-GenericCloud.qcow2.xz
 #fi
-if [ ! -f Fedora-Cloud-Base-27-1.6.x86_64.qcow2 ]; then
-  wget https://dl.fedoraproject.org/pub/fedora/linux/releases/27/CloudImages/x86_64/images/Fedora-Cloud-Base-27-1.6.x86_64.qcow2
+if [ ! -f ${qcow2image} ]; then
+  wget https://dl.fedoraproject.org/pub/fedora/linux/development/rawhide/CloudImages/x86_64/images/${qcow2image}
 fi
 
 popd
@@ -67,6 +72,7 @@ virsh pool-refresh ${PROJECT_NAME}
 
 
 MACHINE_PREFIX=`hostname`
+VM_MEMORY=50G
 echo "Creating ${NUM_VMS_PER_MACHINE} machines:"
 for i in `seq 1 ${NUM_VMS_PER_MACHINE}`
 do
@@ -81,8 +87,8 @@ do
   sed -i s/NODE_NAME/${NODE_NAME}/ meta-data
   genisoimage -output ${NODE_NAME}_cloud-init.iso -volid cidata -joliet -rock user-data meta-data
   #virsh vol-create-as ${PROJECT_NAME} ${NODE_NAME}.qcow2 60G --format qcow2 --backing-vol ${STORAGE_PATH}/CentOS-7-x86_64-GenericCloud.qcow2 --backing-vol-format qcow2
-  virsh vol-create-as ${PROJECT_NAME} ${NODE_NAME}.qcow2 120G --format qcow2 --backing-vol ${STORAGE_PATH}/Fedora-Cloud-Base-27-1.6.x86_64.qcow2 --backing-vol-format qcow2
-  virt-install --connect qemu:///system --ram 18432 -n ${NODE_NAME} --os-type=linux --os-variant=rhel7  --disk path=${VM_PATH}/${NODE_NAME}.qcow2,device=disk,bus=virtio,format=qcow2 --disk path=${VM_PATH}/${NODE_NAME}_config/${NODE_NAME}_cloud-init.iso,device=cdrom,bus=virtio,format=iso --vcpus=2 --graphics spice --noautoconsole --import
+  virsh vol-create-as ${PROJECT_NAME} ${NODE_NAME}.qcow2 ${VM_MEMORY} --format qcow2 --backing-vol ${STORAGE_PATH}/${qcow2image} --backing-vol-format qcow2
+  virt-install --connect qemu:///system --ram 18432 -n ${NODE_NAME} --os-type=linux --os-variant=rhel7  --disk path=${STORAGE_PATH}/${NODE_NAME}.qcow2,device=disk,bus=virtio,format=qcow2 --disk path=${STORAGE_PATH}/${NODE_NAME}_config/${NODE_NAME}_cloud-init.iso,device=cdrom,bus=virtio,format=iso --vcpus=2 --graphics spice --noautoconsole --import
   #virsh attach-interface --domain ${NODE_NAME} --type bridge --source rcbr0 --config --live
   popd
   echo "Done creating machine number $i"

--- a/vmgetip.sh
+++ b/vmgetip.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+NUM_VMS_PER_MACHINE=${NUM_VMS_PER_MACHINE:-5}
+
+host=$(hostname)
+short=$(hostname | cut -d "." -f 1 | cut -d "-" -f 2)
+ips=$(virsh net-dhcp-leases default | grep ipv4 | tr -s " " | cut -d " " -f 6 | head -${NUM_VMS_PER_MACHINE} | cut -d "/" -f 1)
+echo " " >> /etc/hosts
+
+for i in ${ips}
+do
+  hname=$(ssh $i hostname)
+  ind=$(echo ${hname} | sed "s/${host}-//" | sed 's/.example.com//')
+  echo "$i  ${short}-${ind}  ${hname}" >> /etc/hosts
+  ssh ${hname} echo 1
+  ssh ${short}-${ind} echo 2
+done
+exit 0
+

--- a/vmpython.sh
+++ b/vmpython.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Install python in each VM so ansible will work
+
+NUM_VMS_PER_MACHINE=${NUM_VMS_PER_MACHINE:-5}
+
+host=$(hostname)
+short=$(hostname | cut -d "." -f 1 | cut -d "-" -f 2)
+ips=$(virsh net-dhcp-leases default | grep ipv4 | tr -s " " | cut -d " " -f 6 | head -${NUM_VMS_PER_MACHINE} | cut -d "/" -f 1)
+echo " " >> /etc/hosts
+
+for i in ${ips}
+do
+  echo "On host ${i} install python"
+  ssh $i dnf install -y python
+done
+
+exit 0
+


### PR DESCRIPTION
Install ovn on cluster.

Install the cluster on 5VMs on a host. Make sure os_sdn_network_plugin_name='cni'. The cluster is installed with no cni plugin.  The oseovn script installs and configures ovn on the cluster.

Update README-5VM.md to describe this
Update vmcreate.sh for qcow2 file name
Added get-hosts.sh to get host and fqn for each VM based on its IP
Added try-vms.sh to ssh to each host and fqn for the VMs.
Added install-python.sh to install python on each VM (needed by ansible)
Add oseovn script and playbooks to install systemd controlled ovn cni plugin